### PR TITLE
Update leaderboard entry: JudyAgent → TongAgents with BIGAI details

### DIFF
--- a/leaderboard_data.json
+++ b/leaderboard_data.json
@@ -252,7 +252,7 @@
         "name": "TongAgents",
         "date": "2026-02-11",
         "type": "interactive_agent",
-        "tags": ["bigai"],
+        "tags": ["BIGAI"],
         "url": "https://tongagents.mybigai.ac.cn/docs/Tong-Agent/",
         "details": {
           "base_model": "",

--- a/leaderboard_data.json
+++ b/leaderboard_data.json
@@ -249,17 +249,16 @@
     },
     {
       "info": {
-        "name": "JudyAgent",
+        "name": "TongAgents",
         "date": "2026-02-11",
         "type": "interactive_agent",
-        "tags": ["independent"],
-        "url": "",
+        "tags": ["bigai"],
+        "url": "https://tongagents.mybigai.ac.cn/docs/Tong-Agent/",
         "details": {
-          "base_model": "GPT-4.1",
-          "architecture": "Multi-Agent System",
-          "organization": "Independent Researcher",
-          "contact": "Kai Zhou (zhoukai83@outlook.com)",
-          "description": "Multi-agent system with planners and executors."
+          "base_model": "",
+          "architecture": "",
+          "organization": "BIGAI",
+          "contact": "Kai Zhou (zhoukai@bigai.ai)"
         }
       },
       "eval_set": {


### PR DESCRIPTION
## Summary
Updated the leaderboard entry for an interactive agent, replacing JudyAgent with TongAgents and updating associated metadata and organizational information.

## Key Changes
- **Agent name**: Changed from "JudyAgent" to "TongAgents"
- **Organization**: Updated from "Independent Researcher" to "BIGAI"
- **Tags**: Changed from "independent" to "bigai"
- **URL**: Added documentation link (https://tongagents.mybigai.ac.cn/docs/Tong-Agent/)
- **Contact email**: Updated from zhoukai83@outlook.com to zhoukai@bigai.ai
- **Technical details**: Cleared base_model and architecture fields (previously "GPT-4.1" and "Multi-Agent System")
- **Description**: Removed the previous description text

## Notes
This appears to be a correction/update to an existing leaderboard entry, consolidating information under the official BIGAI organization with proper documentation and contact details.

https://claude.ai/code/session_012EFhX8KNUaY2e5yFjRYPjt